### PR TITLE
Gradle buildSrc로 디펜던시 관리

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -22,37 +22,10 @@
  * SOFTWARE.
  */
 
-import databute.Dependency
-
 plugins {
-    java
-    application
+    `kotlin-dsl`
 }
 
-dependencies {
-    implementation(Dependency.netty)
-
-    implementation(Dependency.rxJava)
-
-    implementation(Dependency.commonsLang)
-    implementation(Dependency.curatorFramework)
-    implementation(Dependency.curatorRecipes)
-    implementation(Dependency.gson)
-    implementation(Dependency.guava)
-    implementation(Dependency.slf4j)
-    implementation(Dependency.jacksonDatabind)
-    implementation(Dependency.jacksonDataformatYaml)
-
-    runtimeOnly(Dependency.logback)
-
-    testImplementation(Dependency.junit)
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-application {
-    mainClass.set("databute.databuter.Databuter")
+repositories {
+    mavenCentral()
 }

--- a/buildSrc/src/main/kotlin/databute/Dependency.kt
+++ b/buildSrc/src/main/kotlin/databute/Dependency.kt
@@ -22,37 +22,24 @@
  * SOFTWARE.
  */
 
-import databute.Dependency
+package databute
 
-plugins {
-    java
-    application
-}
+object Dependency {
+    const val netty = "io.netty:netty-all:${Version.netty}"
 
-dependencies {
-    implementation(Dependency.netty)
+    const val rxJava = "io.reactivex.rxjava2:rxjava:${Version.rxJava}"
 
-    implementation(Dependency.rxJava)
+    const val commonsLang = "org.apache.commons:commons-lang3:${Version.commonsLang}"
+    const val curatorFramework = "org.apache.curator:curator-framework:${Version.curator}"
+    const val curatorRecipes = "org.apache.curator:curator-recipes:${Version.curator}"
+    const val gson = "com.google.code.gson:gson:${Version.gson}"
+    const val guava = "com.google.guava:guava:${Version.guava}"
+    const val jacksonDatabind = "com.fasterxml.jackson.core:jackson-databind:${Version.jackson}"
+    const val jacksonDataformatYaml =
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${Version.jackson}"
 
-    implementation(Dependency.commonsLang)
-    implementation(Dependency.curatorFramework)
-    implementation(Dependency.curatorRecipes)
-    implementation(Dependency.gson)
-    implementation(Dependency.guava)
-    implementation(Dependency.slf4j)
-    implementation(Dependency.jacksonDatabind)
-    implementation(Dependency.jacksonDataformatYaml)
+    const val slf4j = "org.slf4j:slf4j-api:${Version.slf4j}"
+    const val logback = "ch.qos.logback:logback-classic:${Version.logback}"
 
-    runtimeOnly(Dependency.logback)
-
-    testImplementation(Dependency.junit)
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-application {
-    mainClass.set("databute.databuter.Databuter")
+    const val junit = "junit:junit:${Version.junit}"
 }

--- a/buildSrc/src/main/kotlin/databute/Dependency.kt
+++ b/buildSrc/src/main/kotlin/databute/Dependency.kt
@@ -25,10 +25,6 @@
 package databute
 
 object Dependency {
-    const val netty = "io.netty:netty-all:${Version.netty}"
-
-    const val rxJava = "io.reactivex.rxjava2:rxjava:${Version.rxJava}"
-
     const val commonsLang = "org.apache.commons:commons-lang3:${Version.commonsLang}"
     const val curatorFramework = "org.apache.curator:curator-framework:${Version.curator}"
     const val curatorRecipes = "org.apache.curator:curator-recipes:${Version.curator}"
@@ -37,9 +33,10 @@ object Dependency {
     const val jacksonDatabind = "com.fasterxml.jackson.core:jackson-databind:${Version.jackson}"
     const val jacksonDataformatYaml =
         "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${Version.jackson}"
-
-    const val slf4j = "org.slf4j:slf4j-api:${Version.slf4j}"
     const val logback = "ch.qos.logback:logback-classic:${Version.logback}"
+    const val netty = "io.netty:netty-all:${Version.netty}"
+    const val rxJava = "io.reactivex.rxjava2:rxjava:${Version.rxJava}"
+    const val slf4j = "org.slf4j:slf4j-api:${Version.slf4j}"
 
     const val junit = "junit:junit:${Version.junit}"
 }

--- a/buildSrc/src/main/kotlin/databute/Version.kt
+++ b/buildSrc/src/main/kotlin/databute/Version.kt
@@ -22,37 +22,21 @@
  * SOFTWARE.
  */
 
-import databute.Dependency
+package databute
 
-plugins {
-    java
-    application
-}
+object Version {
+    const val netty = "4.1.36.Final"
 
-dependencies {
-    implementation(Dependency.netty)
+    const val rxJava = "2.2.10"
 
-    implementation(Dependency.rxJava)
+    const val commonsLang = "3.9"
+    const val curator = "2.13.0"
+    const val gson = "2.8.5"
+    const val guava = "28.0-jre"
+    const val jackson = "2.9.9"
 
-    implementation(Dependency.commonsLang)
-    implementation(Dependency.curatorFramework)
-    implementation(Dependency.curatorRecipes)
-    implementation(Dependency.gson)
-    implementation(Dependency.guava)
-    implementation(Dependency.slf4j)
-    implementation(Dependency.jacksonDatabind)
-    implementation(Dependency.jacksonDataformatYaml)
+    const val slf4j = "1.7.26"
+    const val logback = "1.2.3"
 
-    runtimeOnly(Dependency.logback)
-
-    testImplementation(Dependency.junit)
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-application {
-    mainClass.set("databute.databuter.Databuter")
+    const val junit = "4.12"
 }

--- a/buildSrc/src/main/kotlin/databute/Version.kt
+++ b/buildSrc/src/main/kotlin/databute/Version.kt
@@ -25,18 +25,15 @@
 package databute
 
 object Version {
-    const val netty = "4.1.36.Final"
-
-    const val rxJava = "2.2.10"
-
     const val commonsLang = "3.9"
     const val curator = "2.13.0"
     const val gson = "2.8.5"
     const val guava = "28.0-jre"
     const val jackson = "2.9.9"
-
-    const val slf4j = "1.7.26"
     const val logback = "1.2.3"
+    const val netty = "4.1.36.Final"
+    const val rxJava = "2.2.10"
+    const val slf4j = "1.7.26"
 
     const val junit = "4.12"
 }

--- a/databutee/build.gradle.kts
+++ b/databutee/build.gradle.kts
@@ -22,22 +22,26 @@
  * SOFTWARE.
  */
 
+import databute.Dependency
+
 plugins {
     java
     application
 }
 
 dependencies {
-    implementation("com.google.code.gson:gson:2.8.5")
-    implementation("com.google.guava:guava:28.0-jre")
-    implementation("io.netty:netty-all:4.1.36.Final")
-    implementation("io.reactivex.rxjava2:rxjava:2.2.10")
-    implementation("org.apache.commons:commons-lang3:3.9")
-    implementation("org.slf4j:slf4j-api:1.7.26")
+    implementation(Dependency.netty)
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    implementation(Dependency.rxJava)
 
-    testImplementation("junit:junit:4.12")
+    implementation(Dependency.commonsLang)
+    implementation(Dependency.gson)
+    implementation(Dependency.guava)
+    implementation(Dependency.slf4j)
+
+    runtimeOnly(Dependency.logback)
+
+    testImplementation(Dependency.junit)
 }
 
 java {

--- a/databutee/build.gradle.kts
+++ b/databutee/build.gradle.kts
@@ -32,11 +32,10 @@ plugins {
 dependencies {
     implementation(Dependency.netty)
 
-    implementation(Dependency.rxJava)
-
     implementation(Dependency.commonsLang)
     implementation(Dependency.gson)
     implementation(Dependency.guava)
+    implementation(Dependency.rxJava)
     implementation(Dependency.slf4j)
 
     runtimeOnly(Dependency.logback)

--- a/databuter/build.gradle.kts
+++ b/databuter/build.gradle.kts
@@ -32,16 +32,14 @@ plugins {
 dependencies {
     implementation(Dependency.netty)
 
-    implementation(Dependency.rxJava)
-
     implementation(Dependency.commonsLang)
     implementation(Dependency.curatorFramework)
     implementation(Dependency.curatorRecipes)
     implementation(Dependency.gson)
     implementation(Dependency.guava)
-    implementation(Dependency.slf4j)
     implementation(Dependency.jacksonDatabind)
     implementation(Dependency.jacksonDataformatYaml)
+    implementation(Dependency.slf4j)
 
     runtimeOnly(Dependency.logback)
 


### PR DESCRIPTION
디펜던시들이 한 곳에서 관리되지 않고, databuter와 databutee 모듈 각각 관리되고 있다.
Gradle에서 지원하는 `buildSrc`로 디펜던시를 한 곳으로 모으고, 다른 모듈에서는 참조하는 형태로 디펜던시를 관리하도록 변경한다.